### PR TITLE
address low shared memory (/dev/shm) space issue in Docker container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ then
            --network none \
            --mount type=bind,source=$(pwd)/inference-data,target=/inference/data,readonly \
            --mount type=bind,source=$(pwd)/submission,target=/inference/submission \
+           --ipc=host \
            ai-for-earth-serengeti/inference
 else
     docker build --build-arg CPU_GPU=cpu -t ai-for-earth-serengeti/inference .
@@ -24,5 +25,6 @@ else
             --network none \
             --mount type=bind,source=$(pwd)/inference-data,target=/inference/data,readonly \
             --mount type=bind,source=$(pwd)/submission,target=/inference/submission \
+            --ipc=host \
             ai-for-earth-serengeti/inference
 fi


### PR DESCRIPTION
**Problem**

There is limited amount of shared memory available on the Docker container when run as-is, and Pytorch multiprocessing of any sort will fail because available shared memory is too small.

<details>
<summary>Error</summary>

```

ERROR: Unexpected bus error encountered in worker. This might be caused by insufficient shared memory (shm).                       
Traceback (most recent call last):
  File "/opt/conda/envs/py-cpu/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 724, in _try_get_data             
    data = self.data_queue.get(timeout=timeout)
  File "/opt/conda/envs/py-cpu/lib/python3.6/multiprocessing/queues.py", line 104, in get                                          
    if not self._poll(timeout):
  File "/opt/conda/envs/py-cpu/lib/python3.6/multiprocessing/connection.py", line 257, in poll                                     
    return self._poll(timeout)
  File "/opt/conda/envs/py-cpu/lib/python3.6/multiprocessing/connection.py", line 414, in _poll                                    
    r = wait([self], timeout)
  File "/opt/conda/envs/py-cpu/lib/python3.6/multiprocessing/connection.py", line 911, in wait                                     
    ready = selector.select(timeout)
  File "/opt/conda/envs/py-cpu/lib/python3.6/selectors.py", line 376, in select                                                    
    fd_event_list = self._poll.poll(timeout)
  File "/opt/conda/envs/py-cpu/lib/python3.6/site-packages/torch/utils/data/_utils/signal_handling.py", line 66, in handler        
    _error_if_any_worker_fails()
RuntimeError: DataLoader worker (pid 28) is killed by signal: Bus error. 

```

</details>

**Solution**

Pytorch's [established solution](https://github.com/pytorch/pytorch#docker-image) is using the `--ipc=host` option when running Docker.

This gives a container access to the host's `/dev/shm`.

**Alternative Approaches**

1.) We can also just avoid using multiprocessing for the forward-prop, evaluation step of this competition. However, making this change would help your Docker container be more "production ready" and used in the field, since forward-prop in real life likely would benefit from parallelized dataloading.

2.) We could use the `--shm-size` option to hardcode the size of the container's shared memory instead of using the host's, but it seems clearer to me to have the available shared memory set by the properties of the host machine rather than an arbitrary value. Still, also a good option.

**Risks**

There's a security risk to having Docker using the host machine's shared memory--but hopefully the Azure machine where your runtime exists doesn't contain any sensitive data or anything like that.

